### PR TITLE
Fix optiion name for USE_OPENMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ endif()
 # Dependencies
 
 # OpenMP
-option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
-if(USE_OPENMP)
+option(${LIB_NAME}_USE_OPENMP "If available, use OpenMP for parallelization." ON)
+if(${LIB_NAME}_USE_OPENMP)
   find_package(OpenMP)
 endif()
 


### PR DESCRIPTION
Previously, if I try to run

```
cmake .. -DEventEMin_USE_OPENMP=OFF
```

I got this warning:

```
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    EventEMin_USE_OPENMP
```


I think `LIB_NAME` is missing if you intend to keep it compatible with README.